### PR TITLE
Add request to the upgradeCallback function

### DIFF
--- a/angular2-indexeddb.ts
+++ b/angular2-indexeddb.ts
@@ -27,7 +27,7 @@ export class AngularIndexedDB {
                 };
 
                 request.onupgradeneeded = function (e) {
-                    upgradeCallback(e, self.dbWrapper.db);
+                    upgradeCallback(e, self.dbWrapper.db, request);
                 };
             });
 


### PR DESCRIPTION
Hi, I would to add request to the callback as parameter because I need to add some new fields comming in the new db version.
If I have request in the callback I can easy access to the objectStore like 

let users = request.transaction.objectStore('users');
     users.createIndex("active", "active", { unique: false });

Now is really hard to do this because only request can use standard function of IndexedDb and I like this approach to have open database closed in the one lib function.
If you have better approach how to resolve my problem, I would be happy and teached. Thank you.