### PR TITLE
changed version of angular/core to support version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "service"
   ],
   "dependencies": {
-    "@angular/core": "^4.3.1"
+    "@angular/core": ">=4.3.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
In Angular 5 the compiler shows a warning for angular2-indexeddb, because it loads the @angular/core package version ^4.3.1 and not ^5.0.0. I updated the version range of @angular/core to remove this warning.