### PR TITLE
Improved reject message of the 'openDatabase'

### DIFF
--- a/angular2-indexeddb.ts
+++ b/angular2-indexeddb.ts
@@ -20,7 +20,9 @@ export class AngularIndexedDB {
             };
 
             request.onerror = function (e) {
-                reject("IndexedDB error: " + (<any>e.target).errorCode);
+                reject('IndexedDB error: ' + (<any>e.target).errorCode ?
+                    (<any>e.target).errorCode  + ' (' + (<any>e.target).error + ')' :
+                    (<any>e.target).errorCode);
             };
 
             if (typeof upgradeCallback === "function") {


### PR DESCRIPTION
Improved reject message of the 'openDatabase' method.

In some cases happens exception: UnknownError: Internal error opening backing store for indexedDB.open.
This exception happens when your browser's database is corrupt or your DB has reached the quota limit for your site 
I've seen this error very rarely. 
In this case (<any>e.target).error returns undefined.

Added additional information in reject message.